### PR TITLE
Fix: Configure Astro for SSR to resolve Vercel 404s

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
       applyBaseStyles: true, // Enable Tailwind base styles
     }),
   ],
-  output: 'static', // Static generation for maximum performance
+  output: 'server', // Static generation for maximum performance
   adapter: node({
     mode: 'standalone',
   }),


### PR DESCRIPTION
The Astro configuration `apps/web/astro.config.mjs` was previously set to `output: 'static'`, which is incompatible with the project's use of API routes and the `@astrojs/node` adapter. This likely caused Vercel to deploy your site as purely static, leading to 404 errors for any server-dependent routes.

This commit changes the `output` mode to `'server'`, enabling server-side rendering. This aligns the Astro build output with the requirements of the `@astrojs/node` adapter and should allow Vercel to correctly deploy your application with its server-side capabilities, including the API routes.

## Summary by Sourcery

Configure Astro to use server-side rendering by updating the output mode to 'server', ensuring API routes and SSR features deploy correctly on Vercel.

Bug Fixes:
- Fix Vercel 404s by switching Astro output mode from static to server for SSR support

Enhancements:
- Enable server-side rendering in Astro to support API routes with @astrojs/node adapter

---
## EntelligenceAI PR Summary 
 This PR updates the Astro build target to server-side rendering.
- Changed output in `apps/web/astro.config.mjs` from 'static' to 'server'
- Existing comment was not updated to match the new configuration 

