### PR TITLE
fix: Use pnpm exec for tsup in ui package build

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
     "lint": "eslint . --max-warnings 0",
     "generate:component": "turbo gen react-component",
     "check-types": "tsc --noEmit",
-    "build": "tsup"
+    "build": "pnpm exec tsup"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",


### PR DESCRIPTION
I changed the build script in packages/ui/package.json to use 'pnpm exec tsup' instead of just 'tsup'.

This ensures that the pnpm-managed tsup binary is correctly located and executed, resolving the 'tsup: command not found' error during Vercel builds.

## Summary by Sourcery

Bug Fixes:
- Update the ui package build command to 'pnpm exec tsup' to fix 'tsup: command not found' errors.

---
## EntelligenceAI PR Summary 
 This PR updates the build script in the UI package for improved compatibility with pnpm:
- Changed build script in packages/ui/package.json to use 'pnpm exec tsup' instead of 'tsup'. 

